### PR TITLE
Rule 'no-at-important'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+import { createPlugin } from "stylelint";
+import rules from "./rules";
+
+const rulesPlugins = Object.keys(rules).map(ruleName => {
+  return createPlugin(`itcss/${ruleName}`, rules[ruleName]);
+});
+
+export default rulesPlugins;

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,5 @@
+import noAtImportant from "./no-at-important";
+
+export default {
+  "no-at-important": noAtImportant
+};

--- a/src/rules/no-at-important/README.md
+++ b/src/rules/no-at-important/README.md
@@ -1,0 +1,76 @@
+# no-at-important
+
+This rule forbid the use of `!important`.
+_`!important` make css maintenance hard, you should use it with [care](https://css-tricks.com/when-using-important-is-the-right-choice/)._
+
+## options
+
+### true
+
+The following pattern are considered violations:
+
+```css
+a {
+  color: white !imporant;
+}
+
+.foo {
+  color: white !imporant;
+}
+```
+
+### ignoreLayers: ["string"]
+
+The ITCSS archi is based on [layers](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/), it can be usefull to use `!important` in some of them like the `utilities` one.
+
+This option disable the rule in the layers targeted by the option's content.
+
+For example, given `ignoreLayers: ["utilities"]`
+
+The following patterns are *not* considered violations:
+
+```css
+// file `styles/utilities/_utilities.util.css`
+a {
+  color: white !imporant;
+}
+
+.foo {
+  color: white !imporant;
+}
+```
+
+```css
+// file `styles/utilities/util.css`
+a {
+  color: white !imporant;
+}
+
+.foo {
+  color: white !imporant;
+}
+```
+
+The following patterns are considered violations:
+
+```css
+// file `styles/layer/main.css`
+a {
+  color: white !imporant;
+}
+
+.foo {
+  color: white !imporant;
+}
+```
+
+```css
+// file `styles/layer/_layer.main.css`
+a {
+  color: white !imporant;
+}
+
+.foo {
+  color: white !imporant;
+}
+```

--- a/src/rules/no-at-important/__tests__/fixtures/_layer.style.css
+++ b/src/rules/no-at-important/__tests__/fixtures/_layer.style.css
@@ -1,0 +1,3 @@
+li {
+  color: blue !important;
+}

--- a/src/rules/no-at-important/__tests__/fixtures/style.css
+++ b/src/rules/no-at-important/__tests__/fixtures/style.css
@@ -1,0 +1,3 @@
+li {
+  color: blue !important;
+}

--- a/src/rules/no-at-important/__tests__/index.ts
+++ b/src/rules/no-at-important/__tests__/index.ts
@@ -1,0 +1,68 @@
+import rule, { /*messages,*/ ruleName /*, syntax*/} from "../index";
+import test from "ava";
+import * as stylelint from "stylelint";
+import * as path from "path";
+
+function ruleConfig(config: any[] = [true]) {
+  return {
+    plugins: ["./dist/src"],
+    rules: {
+      [ruleName]: config,
+    }
+  };
+}
+
+test.serial(`${ruleName} - inline code - OK`, async t => {
+  const options = {
+    code: "a{color:blue}",
+    config: ruleConfig()
+    // syntax: syntax,
+  };
+  const output = await stylelint.lint(options);
+  t.falsy(output.errored);
+});
+
+test.serial(`${ruleName} - inline code - KO`, async t => {
+
+  const options = {
+    code: "a{color:blue!important}",
+    config: ruleConfig(),
+    // syntax: syntax,
+  };
+  const output = await stylelint.lint(options);
+  t.true(output.errored);
+});
+
+test.serial(`${ruleName} - layers options - ok`, async t => {
+
+  const options = {
+    files: ["**/fixtures/_layer.style.css"],
+    config: ruleConfig([true, { ignoreLayers: ["layer"] }]),
+    // syntax: syntax,
+  };
+  const output = await stylelint.lint(options);
+  t.false(output.errored);
+});
+
+test.serial(`${ruleName} - layers options - ko`, async t => {
+
+  const stylelintConfig = {
+    plugins: ["./dist/src"],
+    rules: {
+      [ruleName]: [
+        true,
+        {
+          exceptLayers: ["layer"]
+        }
+      ]
+    }
+  };
+
+  const options = {
+    files: ["**/fixtures/style.css"],
+    config: ruleConfig([true, { ignoreLayers: ["layer"] }]),
+    // syntax: syntax,
+  };
+  const output = await stylelint.lint(options);
+  t.true(output.errored);
+});

--- a/src/rules/no-at-important/index.ts
+++ b/src/rules/no-at-important/index.ts
@@ -1,0 +1,82 @@
+import * as path from "path";
+import { utils } from "stylelint";
+// import isStandardSyntaxRule from "stylelint/lib/utils/isStandardSyntaxRule";
+
+export const ruleName = "itcss/no-at-important";
+
+export const messages = utils.ruleMessages(ruleName, {
+  // expected: selector => `Unexpected using "{ display: none; }" in ${selector}`,
+  expected: `Use of "!important" is forbidden in this layers`,
+
+});
+
+interface RuleOption {
+  ignoreLayers?: string[];
+}
+const exceptLayersDefault = [
+  "utilities"
+];
+
+function check(node) {
+  if (node.type !== "rule") {
+    return true;
+  }
+
+  return node.nodes.some(
+    o => o.type === "decl" && o.important === true
+  );
+}
+
+function rule(enable, options: RuleOption = {}) {
+  return (root, result) => {
+
+    // const validOptions = utils.validateOptions(result, ruleName, { enable }); // 🤷‍♂️
+    if (enable === false) {
+      return;
+    }
+
+    const filePath: path.ParsedPath = path.parse(result.opts.from || "");
+    options.ignoreLayers = options.ignoreLayers || []; // no default
+    let isIgnoredLayer = false;
+    isIgnoredLayer = options.ignoreLayers.some(layer => {
+      let test = filePath.dir.split(path.sep).indexOf(layer) !== -1;
+      if (test === false) {
+        test = filePath.name.match(layer) !== null;
+      }
+      return test;
+    });
+
+    if (isIgnoredLayer) {
+      return;
+    }
+
+    root.walk(node => {
+      let selector = node.selector;
+      // if (node.type === "rule") {
+        // if (!isStandardSyntaxRule(node)) {
+        //   return;
+        // }
+        // selector = node.selector;
+      // } // else if (node.type === "atrule" && node.name.toLowerCase() === "page" && node.params) {
+      //   selector = node.params;
+      // }
+
+      if (!selector) {
+        return;
+      }
+      const containAtImportant = check(node);
+      if (containAtImportant === true) {
+        utils.report({
+          index: node.lastEach,
+          message: messages.expected,
+          node,
+          ruleName,
+          result
+        });
+      }
+    });
+
+  };
+}
+
+export default rule;


### PR DESCRIPTION
This rule disallow the use of `!important` in the style. With the ITCSS architecture use of `!important` should not be necessary. However `!important` can be useful for util class (like `text-center`), this is why the rule accept an option `ignoreLayers` which permit to accept the use of `!important` in some layers.